### PR TITLE
Added multi language support

### DIFF
--- a/app/features/dynamo/core.py
+++ b/app/features/dynamo/core.py
@@ -3,19 +3,19 @@ from app.features.dynamo.tools import get_summary, summarize_transcript_youtube_
 
 logger = setup_logger(__name__)
 
-def executor(file_url: str, file_type: str, verbose=True):
+def executor(file_url: str, file_type: str, lang: str="en", verbose=True):
     if (verbose):
         logger.info(f"File URL loaded: {file_url}")
     flashcards = []
 
     if file_type == "img":
-        flashcards = generate_concepts_from_img(file_url)
+        flashcards = generate_concepts_from_img(file_url, lang)
     elif (file_type == 'youtube_url'):
         summary = summarize_transcript_youtube_url(file_url, verbose=verbose)
-        flashcards = generate_flashcards(summary, verbose)
+        flashcards = generate_flashcards(summary, lang, verbose)
     else:
         summary = get_summary(file_url, file_type, verbose=verbose)
-        flashcards = generate_flashcards(summary, verbose)
+        flashcards = generate_flashcards(summary, lang, verbose)
 
 
     sanitized_flashcards = []

--- a/app/features/dynamo/prompt/dynamo-prompt.txt
+++ b/app/features/dynamo/prompt/dynamo-prompt.txt
@@ -12,6 +12,6 @@ Formatting:
 -----------------------------
 {format_instructions}
 
-Respond only according to the format instructions. The examples included are best responses noted by an input and output example.
+Respond only according to the format instructions. The examples included are best responses noted by an input and output example. You must provide the response in "{lang}" language. 
 
 Output:


### PR DESCRIPTION
And add multi-language support for dynamo.
I've implemented this such that the "lang" is optional in the request. The default "lang" is English.
```json
{
  "user": {
    "id": "string",
    "fullName": "string",
    "email": "string"
  },
  "type": "tool",
  "tool_data": {
    "tool_id": 1,
    "inputs": [
      {
        "name": "file_url",
        "value": "https://firebasestorage.googleapis.com/v0/b/kai-ai-f63c8.appspot.com/o/uploads%2F510f946e-823f-42d7-b95d-d16925293946-Linear%20Regression%20Stat%20Yale.pdf?alt=media&token=caea86aa-c06b-4cde-9fd0-42962eb72ddd"
      },
      {
        "name": "file_type",
        "value": "pdf"
      },
      {
         "name": "lang",
         "value": "Swedish"
      }
    ]
  }
}
```
![Screenshot 2024-07-25 at 12 03 14 PM](https://github.com/user-attachments/assets/4e85f1c5-4fbd-43f4-ab63-b70edd45701d)

