### PR TITLE
Added multi language support

### DIFF
--- a/app/features/syllabus_generator/core.py
+++ b/app/features/syllabus_generator/core.py
@@ -17,6 +17,7 @@ def executor(grade_level: str,
             grading_scale: str,
             file_url: str,
             file_type: str,
+            lang: str = "en",
             verbose: bool = True):
     
     if verbose:
@@ -41,6 +42,7 @@ def executor(grade_level: str,
                                 start_date,
                                 assessment_methods,
                                 grading_scale,
+                                lang,
                                 summary)
         
         syllabus = generate_syllabus(request_args, verbose=verbose)

--- a/app/features/syllabus_generator/prompt/syllabus_generator-prompt.txt
+++ b/app/features/syllabus_generator/prompt/syllabus_generator-prompt.txt
@@ -25,3 +25,5 @@ For the course's content and detail, please guide with this summary: {summary}
 
 You must respond as a JSON object:
 {format_instructions}
+
+You must provide the questions and answers in response in "{lang}" language.

--- a/app/features/syllabus_generator/tools.py
+++ b/app/features/syllabus_generator/tools.py
@@ -27,6 +27,7 @@ class SyllabusRequestArgs:
         self._start_date = syllabus_generator_args.start_date
         self._assessment_methods = syllabus_generator_args.assessment_methods
         self._grading_scale = syllabus_generator_args.grading_scale
+        self._lang = syllabus_generator_args.lang
         self._summary = summary
 
     @property

--- a/app/features/syllabus_generator/tools.py
+++ b/app/features/syllabus_generator/tools.py
@@ -23,6 +23,7 @@ class SyllabusRequestArgs:
                  start_date: str, 
                  assessment_methods: str, 
                  grading_scale: str,
+                 lang: str,
                  summary: str):
         
         self._grade_level = grade_level
@@ -34,6 +35,7 @@ class SyllabusRequestArgs:
         self._start_date = start_date
         self._assessment_methods = assessment_methods
         self._grading_scale = grading_scale
+        self._lang = lang
         self._summary = summary
 
     @property
@@ -73,6 +75,10 @@ class SyllabusRequestArgs:
         return self._grading_scale
     
     @property
+    def lang(self) -> str:
+        return self._lang
+    
+    @property
     def summary(self) -> str:
         return self._summary
     
@@ -87,6 +93,7 @@ class SyllabusRequestArgs:
             "start_date": self.start_date,
             "assessment_methods": self.assessment_methods,
             "grading_scale": self.grading_scale,
+            "lang": self.lang,
             "summary": self.summary
         }
     

--- a/app/services/schemas.py
+++ b/app/services/schemas.py
@@ -67,3 +67,4 @@ class SyllabusGeneratorArgsModel(BaseModel):
     grading_scale: str
     file_url: str
     file_type: str
+    lang: Optional[str] = "en"


### PR DESCRIPTION
And add multi-language support for the Syllabus Generator.
I've implemented this such that the "lang" is optional in the request. The default "lang" is English.

```json
{
   "user":{
      "id":"string",
      "fullName":"string",
      "email":"string"
   },
   "type":"chat",
   "tool_data":{
      "tool_id":6,
      "inputs":[
         {
            "name":"syllabus_generator_args",
            "value":{
               "grade_level":"College",
               "course":"Linear Regression",
               "instructor_name":"Amrutha Vinayakam",
               "instructor_title":"Master in Artificial Intelligence",
               "unit_time":"week",
               "unit_time_value":8,
               "start_date":"July, 4th, 2024",
               "assessment_methods":"project and exams",
               "grading_scale":"In percentages (100%)",
               "file_url":"https://firebasestorage.googleapis.com/v0/b/kai-ai-f63c8.appspot.com/o/uploads%2F510f946e-823f-42d7-b95d-d16925293946-Linear%20Regression%20Stat%20Yale.pdf?alt=media&token=caea86aa-c06b-4cde-9fd0-42962eb72ddd",
               "file_type":"pdf",
               "lang": "chinese"
            }
         }
      ]
   }
}
```

<img width="1267" alt="Screenshot 2024-07-25 at 12 38 52 PM" src="https://github.com/user-attachments/assets/79f9c980-9e7e-4ab0-b0ad-36ec7e503c9b">
